### PR TITLE
Fix unicodedecodeerror

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -124,9 +124,14 @@ examples = [
     "A photo of beautiful mountain with realistic sunset and blue lake, highly detailed, masterpiece",
 ]
 
-
+def load_css(filename):
+    with open(filename, encoding='utf-8') as css_file:
+        return css_file.read()
+    
 def on_ui_tabs():
-    with gr.Blocks(css="style.css") as lcm:
+    css_content = load_css("style.css")
+    with gr.Blocks(css=css_content) as lcm:
+    # with gr.Blocks(css="style.css") as lcm:
         gr.Markdown(DESCRIPTION)
         with gr.Group():
             with gr.Row():

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -129,7 +129,7 @@ def load_css(filename):
         return css_file.read()
     
 def on_ui_tabs():
-    css_content = load_css("style.css")
+    css_content = load_css("styles.css")
     with gr.Blocks(css=css_content) as lcm:
     # with gr.Blocks(css="style.css") as lcm:
         gr.Markdown(DESCRIPTION)


### PR DESCRIPTION
When starting the WebUI

 When trying to read css

`nicodeDecodeError: 'cp932' codec can't decode byte 0x97 in position 12023: illegal multibyte sequence`

I get an error like this.

I created a function that reads a CSS file in scripts/main.py, encodes css in UTF-8, and used that function to pass the CSS content to gr.Blocks.
It works on my enviroment